### PR TITLE
Adicionar blueprint oficial e plano de execução Fase 1; atualizar README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ Sistema e biblioteca (Markdown-first) para estruturar e automatizar operação c
 
 ## Estrutura
 
-- `docs/`: visão, literatura, jornada e arquitetura
+- `docs/`: visão, literatura, jornada, blueprint e arquitetura
 - `backend/`: backend do produto
 - `agents/`: agentes (prompts, specs, implementações)
 - `experiments/`: scripts e protótipos
 
+
+## Próximos passos
+
+- Blueprint oficial do projeto: `docs/blueprint/ruptur-blueprint.md`
+- Plano de execução fase 1: `docs/jornada/proximos_passos_fase1.md`

--- a/docs/blueprint/ruptur-blueprint.md
+++ b/docs/blueprint/ruptur-blueprint.md
@@ -1,0 +1,296 @@
+# Blueprint oficial — Ruptur
+
+## 1) Origem
+
+O Ruptur nasce da observação de um problema recorrente no empreendedor brasileiro: existe acesso a tecnologia, IA e plataformas digitais, mas falta uma forma **simples e prática** de operar tudo isso no dia a dia.
+
+Na prática, muitos empreendedores precisam aprender integrações, APIs e automações antes de conseguir tocar a operação comercial com previsibilidade.
+
+**Hipótese fundadora:** o empreendedor não deveria operar ferramentas; as ferramentas deveriam operar para o empreendedor.
+
+## 2) Tese central
+
+O empreendedor não precisa aprender tecnologia.
+A tecnologia precisa operar para ele.
+
+O Ruptur é um núcleo de automação empresarial que:
+
+- conecta ferramentas existentes;
+- orquestra agentes especialistas;
+- executa processos operacionais;
+- responde a comandos simples (incluindo áudio).
+
+## 3) Problema que resolvemos
+
+Hoje a operação comercial costuma estar fragmentada em:
+
+- WhatsApp;
+- CRM;
+- agenda;
+- automações;
+- marketing;
+- follow-up;
+- relatórios.
+
+Resultados comuns da fragmentação:
+
+- leads perdidos;
+- follow-ups esquecidos;
+- oportunidades desperdiçadas;
+- sobrecarga cognitiva.
+
+## 4) Experiência do usuário (UX alvo)
+
+Interação natural e orientada à execução.
+
+### Exemplo
+
+**Entrada (áudio):**
+
+> “Veja como estão os leads hoje e marque visita para os mais interessados.”
+
+**Fluxo interno:**
+
+1. transcrição;
+2. interpretação da intenção;
+3. planejamento da tarefa;
+4. execução por agentes;
+5. resposta resumida.
+
+**Saída esperada:**
+
+> “Hoje entraram 17 leads. 4 estão quentes. Marquei visita com 2 para amanhã.”
+
+## 5) Arquitetura conceitual
+
+A arquitetura combina três pilares:
+
+### MCP (Model Context Protocol)
+
+Conexão com ferramentas externas sem recriá-las.
+
+Exemplos de conectores:
+
+- Supabase;
+- Google Calendar;
+- WhatsApp APIs;
+- Notion;
+- Gmail.
+
+### ADK (Agent Development Kit)
+
+Estrutura modular para agentes especializados, por exemplo:
+
+- lead sentinel;
+- conversation agent;
+- follow-up agent;
+- calendar agent;
+- report agent;
+- memory agent.
+
+Cada agente tem responsabilidades claras, skills e plugins.
+
+### A2A (Agent-to-Agent)
+
+Coordenação entre agentes.
+
+Exemplo: o agente central delega simultaneamente para qualificação, agenda e follow-up.
+
+## 6) Superagente (orquestrador)
+
+Nome conceitual: **Jarvis**.
+
+Papel:
+
+- receber solicitações;
+- interpretar intenção;
+- decompor tarefas;
+- coordenar agentes especialistas;
+- consolidar e responder resultados.
+
+## 7) Princípio técnico fundamental
+
+**API-first**. As interfaces são superfícies; o núcleo é a API.
+
+Fluxo lógico:
+
+```text
+User
+↓
+Interface (WhatsApp / Web / CLI)
+↓
+API
+↓
+Event System
+↓
+Orchestrator
+↓
+Agents
+↓
+Tools (MCP)
+```
+
+## 8) Stack inicial (fase 1)
+
+Critério: priorizar o que já existe com tier gratuito.
+
+- **Infra:** Supabase (banco, storage, edge functions)
+- **Comunicação:** WhatsApp API
+- **Agenda:** Google Calendar API
+- **IA:** OpenAI ou modelo compatível
+- **Backend:** Python
+- **Orquestração:** arquitetura orientada a eventos
+
+## 9) Estrutura alvo do repositório
+
+```text
+ruptur/
+  core/
+    api/
+    events/
+    orchestrator/
+
+  agents/
+    lead_sentinel/
+    conversation/
+    followup/
+    calendar/
+    report/
+
+  skills/
+    crm/
+    qualification/
+    sales/
+    operations/
+
+  plugins/
+    supabase/
+    google_calendar/
+    whatsapp/
+
+  docs/
+    genesis/
+    arquitetura/
+    manifesto/
+    blueprint/
+
+  experiments/
+```
+
+## 10) Próximos passos (execução)
+
+1. fechar modelagem mínima de dados (`leads`, `conversations`, `messages`, `pipeline_events`);
+2. criar webhook de entrada e persistência idempotente de mensagens;
+3. implementar qualificação v1 por regras;
+4. implementar rotina de follow-up para contatos sem resposta;
+5. criar visão simples de pipeline por estágio;
+6. consolidar o primeiro fluxo completo em produção assistida.
+
+> Plano operacional detalhado: `docs/jornada/proximos_passos_fase1.md`.
+
+## 11) Roadmap
+
+### Fase 1 — Ruptur Core
+
+Objetivo: operar um negócio real com previsibilidade.
+
+Capacidades:
+
+- captura de leads;
+- memória de conversa;
+- classificação;
+- follow-up;
+- agenda.
+
+### Fase 2 — Templates de operação
+
+Pacotes por segmento:
+
+- imobiliária;
+- agência;
+- serviços locais.
+
+### Fase 3 — Plugins MCP adicionais
+
+Integrações com:
+
+- CRMs externos;
+- automação de marketing;
+- plataformas de anúncio.
+
+### Fase 4 — Produto replicável
+
+Empacotar playbooks, observabilidade e onboarding para escala.
+
+## 12) Princípios de design
+
+A simplicidade de uso é mandatória.
+
+Exemplo conceitual:
+
+```python
+ruptur.connect("supabase")
+ruptur.connect("google_calendar")
+ruptur.connect("whatsapp")
+
+ruptur.run("qualifique novos leads e agende visitas")
+```
+
+## 13) Direção do produto
+
+O Ruptur **não é**:
+
+- CRM tradicional;
+- chatbot isolado;
+- automação visual sem contexto.
+
+O Ruptur **é**:
+
+- infraestrutura de automação empresarial orientada por agentes.
+
+## 14) Referências (livros, repositórios e vídeos)
+
+### Livro de base
+
+- *Receita Previsível* — Aaron Ross & Marylou Tyler (`docs/literatura/receita_previsivel.md`)
+
+### Repositórios
+
+- Interface Design: <https://github.com/Dammyjay93/interface-design>
+- Claude Code frontend plugin: <https://github.com/anthropics/claude-code/tree/main/plugins/frontend-design>
+
+### Vídeos analisados
+
+- Design e frontend: <https://www.youtube.com/watch?v=ddBlmSQGVrU>
+- Agent frameworks e automação:
+  - <https://www.youtube.com/watch?v=c0nJB1y-SQI>
+  - <https://www.youtube.com/watch?v=GpY41sPt5hA>
+  - <https://www.youtube.com/watch?v=duWhy3-iG38>
+  - <https://www.youtube.com/watch?v=6AxZMW-sQrY>
+  - <https://www.youtube.com/watch?v=yt3z6t8cLzE>
+  - <https://www.youtube.com/watch?v=52BZ24-a9kQ>
+  - <https://www.youtube.com/watch?v=BqU0cUJRjh4>
+  - <https://www.youtube.com/watch?v=ZuOEuVJK86Y>
+  - <https://www.youtube.com/watch?v=ssiHUVbkRIo>
+
+## 15) Apêndice
+
+### A) Contexto cultural brasileiro
+
+Muitos empreendedores operam com:
+
+- mensagens de áudio;
+- WhatsApp como canal principal;
+- comunicação rápida e informal;
+- baixa tolerância a setup técnico complexo.
+
+O Ruptur deve se adaptar a esse contexto, e não exigir que o usuário se adapte ao software.
+
+### B) Filosofia do projeto
+
+O empreendedor deve focar no seu ofício.
+O Ruptur cuida da máquina operacional.
+
+### C) Frase de síntese
+
+**Ruptur conecta agentes, ferramentas e plataformas para operar processos de negócio. Você descreve o que precisa. O Ruptur resolve.**

--- a/docs/jornada/proximos_passos_fase1.md
+++ b/docs/jornada/proximos_passos_fase1.md
@@ -1,0 +1,75 @@
+# Próximos passos — Fase 1 (custo zero)
+
+Este plano transforma a jornada do `ChatGPT - Ruptur` em execução prática.
+
+## Objetivo da fase 1
+
+Validar o núcleo do Ruptur com baixo risco e zero custo operacional fixo:
+
+1. Capturar lead vindo de WhatsApp.
+2. Salvar histórico e contexto de conversa.
+3. Classificar lead com regras simples.
+4. Executar follow-up automático básico.
+5. Exibir pipeline mínimo para previsibilidade.
+
+## Stack sugerida (fase 1)
+
+- **Backend:** Python + FastAPI
+- **Banco:** PostgreSQL local (Docker) durante desenvolvimento
+- **Automação complementar:** n8n apenas para fluxos periféricos
+- **Base de conhecimento:** Markdown + Git (este repositório)
+
+> Regra: lógica crítica fica no backend; n8n não é o core.
+
+## Definição de pronto do MVP
+
+O MVP está pronto quando, de ponta a ponta:
+
+- uma mensagem recebida gera/atualiza lead;
+- a conversa fica persistida;
+- o lead recebe um status de qualificação (`novo`, `contato`, `qualificado`, `desqualificado`);
+- existe uma rotina de follow-up para contatos sem resposta;
+- existe uma visão simples de pipeline por estágio.
+
+## Backlog priorizado
+
+## Sprint 0 — Fundamentos
+
+- [ ] Criar `backend/` com estrutura inicial.
+- [ ] Definir schema inicial: `leads`, `conversations`, `messages`, `pipeline_events`.
+- [ ] Configurar `.env.example` e settings.
+- [ ] Criar endpoint healthcheck.
+
+## Sprint 1 — Ingestão e memória
+
+- [ ] Endpoint de webhook de entrada.
+- [ ] Persistência idempotente de mensagens.
+- [ ] Upsert de lead por telefone/identificador.
+- [ ] Timeline de conversa por lead.
+
+## Sprint 2 — Qualificação e follow-up
+
+- [ ] Motor de qualificação v1 baseado em regras.
+- [ ] Job de follow-up (contatos sem resposta em X horas).
+- [ ] Registro de eventos de pipeline.
+- [ ] Relatório básico: leads por estágio.
+
+## Métricas mínimas da fase 1
+
+- Tempo médio entre primeiro contato e qualificação.
+- Taxa de resposta após follow-up.
+- Volume semanal de leads por estágio.
+- Percentual de leads sem próximo passo definido.
+
+## Riscos e mitigação
+
+- **Risco:** dependência excessiva de ferramentas de automação.
+  - **Mitigação:** concentrar regras de negócio no backend.
+- **Risco:** dados inconsistentes de conversa.
+  - **Mitigação:** idempotência por `message_id` + auditoria de eventos.
+- **Risco:** escopo grande demais para fase 1.
+  - **Mitigação:** operar com apenas 4 estágios e regras simples.
+
+## Próxima entrega sugerida
+
+Implementar o **Sprint 0 completo** com código executável e migração inicial de banco.


### PR DESCRIPTION
### Motivation

- Centralizar a visão, arquitetura e roteiro do projeto em um blueprint oficial para orientar desenvolvimento e decisões técnicas.
- Fornecer um plano prático de execução (Fase 1) com backlog priorizado e definição de pronto para viabilizar o MVP rapidamente.
- Tornar o README mais informativo ao apontar para os artefatos de arquitetura e próximos passos.

### Description

- Adiciona `docs/blueprint/ruptur-blueprint.md` com tese do projeto, experiência do usuário alvo, arquitetura conceitual (MCP/ADK/A2A), orquestrador, stack inicial e roadmap por fases.
- Adiciona `docs/jornada/proximos_passos_fase1.md` com objetivo da fase 1, stack sugerida, definição de pronto do MVP, backlog priorizado (Sprint 0 a Sprint 2), métricas e riscos/mitigações.
- Atualiza `README.md` para mencionar `docs/` incluindo blueprint e uma nova seção "Próximos passos" com links para os documentos adicionados.

### Testing

- Nenhum teste automatizado foi executado, pois a mudança é exclusivamente de documentação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24da3062c832e8aae62d3107d18e6)